### PR TITLE
Update the configuration to support Cray and Fujitsu compilers

### DIFF
--- a/scripts/checkout_and_build_cmake.py
+++ b/scripts/checkout_and_build_cmake.py
@@ -166,7 +166,7 @@ def main():
     (options, args) = parser.parse_args()
     
     # sanity check: we could not use Cray and Fujitsu compilers at the same time
-    expect (not (options.iscray and options.isfujitsu), "iscray and isfujitsu could not be both True)
+    expect (not (options.iscray and options.isfujitsu), "iscray and isfujitsu could not be both True")
             
     if (options.verbose):
         options.debug = True

--- a/scripts/checkout_and_build_cmake.py
+++ b/scripts/checkout_and_build_cmake.py
@@ -158,9 +158,16 @@ def main():
                       dest='iscray', default=False,
                       action="store_true",
                       help='True if the Cray compiler is used')
-
+    parser.add_option('--isfujitsu',
+                      dest='isfujitsu', default=False,
+                      action="store_true",
+                      help='True if the Fujitsu compiler is used')
+    
     (options, args) = parser.parse_args()
     
+    # sanity check: we could not use Cray and Fujitsu compilers at the same time
+    expect (not (options.iscray and options.isfujitsu), "iscray and isfujitsu could not be both True)
+            
     if (options.verbose):
         options.debug = True
 
@@ -489,10 +496,15 @@ def createCMakeLists():
     if (options.iscray):
        iscrayStr = " --iscray "
 
+    isfujitsuStr = ""
+    if (options.isfujitsu):
+       isfujitsuStr = " --isfujitsu "
+            
     shellCmd("../build/cmake/createCMakeLists.py " +
              debugStr + staticStr + verboseMakeStr +
              withJasperStr + dependDirsStr + m32Str +
-             " --prefix " + prefixDir + iscrayStr)
+             " --prefix " + prefixDir + iscrayStr +
+             isfujitsuStr)
 
 ########################################################################
 # write release information file

--- a/scripts/checkout_and_build_cmake.py
+++ b/scripts/checkout_and_build_cmake.py
@@ -166,7 +166,7 @@ def main():
     (options, args) = parser.parse_args()
     
     # sanity check: we could not use Cray and Fujitsu compilers at the same time
-    expect (not (options.iscray and options.isfujitsu), "iscray and isfujitsu could not be both True")
+    assert not (options.iscray and options.isfujitsu), "iscray and isfujitsu could not be both True..."
             
     if (options.verbose):
         options.debug = True

--- a/scripts/checkout_and_build_cmake.py
+++ b/scripts/checkout_and_build_cmake.py
@@ -272,7 +272,9 @@ def main():
         print("  build_vortrac: ", options.build_vortrac, file=sys.stderr)
         print("  build_samurai: ", options.build_samurai, file=sys.stderr)
         print("  noApps: ", options.noApps, file=sys.stderr)
-
+        print("  iscray: ", options.iscray, file=sys.stderr)
+        print("  isfujitsu: ", options.isfujitsu, file=sys.stderr)
+        
     # create build dir
     
     createBuildDir()

--- a/scripts/checkout_and_build_cmake.py
+++ b/scripts/checkout_and_build_cmake.py
@@ -154,6 +154,10 @@ def main():
                       dest='verboseMake', default=False,
                       action="store_true",
                       help='Verbose output for make, default is summary')
+    parser.add_option('--iscray',
+                      dest='iscray', default=False,
+                      action="store_true",
+                      help='True if the Cray compiler is used')
 
     (options, args) = parser.parse_args()
     
@@ -481,10 +485,14 @@ def createCMakeLists():
     if (options.buildNetcdf):
         dependDirsStr = " --dependDirs " + prefixDir + " "
 
+    iscrayStr = ""
+    if (options.iscray):
+       iscrayStr = " --iscray "
+
     shellCmd("../build/cmake/createCMakeLists.py " +
              debugStr + staticStr + verboseMakeStr +
              withJasperStr + dependDirsStr + m32Str +
-             " --prefix " + prefixDir)
+             " --prefix " + prefixDir + iscrayStr)
 
 ########################################################################
 # write release information file


### PR DESCRIPTION
We update the configuration files so that we could compile the samurai package using the Cray and Fujitsu compilers. Two new options `iscray` and `isfujitsu` are added to specify some specific flags for these two new compilers.

We use the GCC version of HDF5 and NetCDF libraries that come with the host machine.

An example to compile the samurai package using the Cray compiler looks like:
`./checkout_and_build_cmake.py --verbose --package samurai --iscray`

An example to compile the samurai package using the Fujitsu compiler looks like:
`./checkout_and_build_cmake.py --verbose --package samurai --isfujitsu`

This PR needs to be combined with the PR at https://github.com/NCAR/lrose-core/pull/96 in order to work correctly.